### PR TITLE
Custom json serialization for cisco's gpbkv format

### DIFF
--- a/src/mdt_dialout_core.h
+++ b/src/mdt_dialout_core.h
@@ -3,8 +3,9 @@
 
 #include <iostream>
 #include <grpcpp/grpcpp.h>
-//#include <json/json.h>
+#include <json/json.h>
 #include "cisco_dialout.grpc.pb.h"
+#include "cisco_telemetry.grpc.pb.h"
 #include "huawei_dialout.grpc.pb.h"
 #include "grpc/socket_mutator.h"
 
@@ -30,6 +31,11 @@ public:
     int str2json(const std::string& json_str);
     int str2json_(const std::string& json_str, std::string& json_str_out);
     int async_kafka_prod(const std::string& json_str);
+    int cisco_gpbkv2json(
+        const std::unique_ptr<cisco_telemetry::Telemetry>& cisco_tlm,
+        std::string& json_str_out);
+    Json::Value cisco_gpbkv_field2json(const cisco_telemetry::TelemetryField& field);
+
 private:
 };
 


### PR DESCRIPTION
The default protobuf serialization for Cisco gpbkv is very verbose. We move the keys from values to proper json keys and only serialize the values that are useful. The behavior of everything but Cisco's gppkv is kept as it.

A small addition to serialize json to string with indentation="" this saves space in transport.